### PR TITLE
Add Rocky Linux 9 support and update repo URLs

### DIFF
--- a/ApachController/ApacheController.py
+++ b/ApachController/ApacheController.py
@@ -263,7 +263,7 @@ LoadModule mpm_event_module modules/mod_mpm_event.so
         # Version 5.4
 
         if ProcessUtilities.decideDistro() in [ProcessUtilities.centos, ProcessUtilities.cent8, ProcessUtilities.cent9]:
-            if ProcessUtilities.alma9check == 1:
+            if ProcessUtilities.rhel9check == 1:
                 command = 'yum install -y https://rpms.remirepo.net/enterprise/remi-release-9.rpm'
             else:
                 command = 'yum install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm'

--- a/CPScripts/mailscannerinstaller.sh
+++ b/CPScripts/mailscannerinstaller.sh
@@ -114,6 +114,27 @@ elif [[ $Server_OS = "CentOS" ]] && [[ "$Server_OS_Version" = "8" ]] ; then
 
   freshclam -v
 
+elif [[ $Server_OS = "CentOS" ]] && [[ "$Server_OS_Version" = "9" ]] ; then
+
+  setenforce 0
+  yum install -y perl yum-utils perl-CPAN
+  dnf install -y dnf-plugins-core
+  dnf config-manager --set-enabled crb
+  dnf install -y perl-IO-stringy
+  yum install -y gcc cpp perl bzip2 zip make patch automake rpm-build perl-Archive-Zip perl-Filesys-Df perl-OLE-Storage_Lite perl-Net-CIDR perl-DBI perl-MIME-tools perl-DBD-SQLite binutils glibc-devel perl-Filesys-Df zlib unzip zlib-devel wget mlocate clamav clamav-update "perl(DBD::mysql)"
+  dnf install -y unrar
+
+  export PERL_MM_USE_DEFAULT=1
+  curl -L https://cpanmin.us | perl - App::cpanminus
+
+  perl -MCPAN -e 'install Encoding::FixLatin'
+  perl -MCPAN -e 'install Digest::SHA1'
+  perl -MCPAN -e 'install Geo::IP'
+  perl -MCPAN -e 'install Razor2::Client::Agent'
+  perl -MCPAN -e 'install Net::Patricia'
+
+  freshclam -v
+
 elif [ "$CLNVERSION" = "ID=\"cloudlinux\"" ]; then
 
   setenforce 0

--- a/CPScripts/mailscanneruninstaller.sh
+++ b/CPScripts/mailscanneruninstaller.sh
@@ -43,6 +43,10 @@ elif [[ $Server_OS = "CentOS" ]] && [[ "$Server_OS_Version" = "8" ]] ; then
 
   yum remove -y MailScanner
 
+elif [[ $Server_OS = "CentOS" ]] && [[ "$Server_OS_Version" = "9" ]] ; then
+
+  yum remove -y MailScanner
+
 elif [[ $Server_OS = "Ubuntu" ]]; then
 
  apt purge -y mailscanner

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -176,6 +176,10 @@ Total_RAM=$(free -m | awk '/Mem:/ { print $2 }')
 
 Remote_MySQL="Off"
 
+# Pin MariaDB to latest LTS
+MARIADB_VERSION="10.11.4"
+MARIADB_MAJOR="${MARIADB_VERSION%.*}"
+
 Final_Flags=()
 
 Git_User=""
@@ -287,22 +291,22 @@ gpgcheck=1
 EOF
     elif [[ "$Server_OS_Version" = "8" ]]; then
         cat <<EOF >/etc/yum.repos.d/MariaDB.repo
-# MariaDB 10.11 RHEL8 repository list
+# MariaDB ${MARIADB_MAJOR} RHEL8 repository list
 # http://downloads.mariadb.org/mariadb/repositories/
 [mariadb]
 name = MariaDB
-baseurl = http://yum.mariadb.org/10.11/rhel8-amd64
+baseurl = http://yum.mariadb.org/${MARIADB_MAJOR}/rhel8-amd64
 module_hotfixes=1
 gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1
 EOF
     elif [[ "$Server_OS_Version" = "9" ]] && uname -m | grep -q 'x86_64'; then
         cat <<EOF >/etc/yum.repos.d/MariaDB.repo
-# MariaDB 10.11 CentOS repository list - created 2021-08-06 02:01 UTC
+# MariaDB ${MARIADB_MAJOR} CentOS repository list - created 2021-08-06 02:01 UTC
 # http://downloads.mariadb.org/mariadb/repositories/
 [mariadb]
 name = MariaDB
-baseurl = http://yum.mariadb.org/10.11/rhel9-amd64/
+baseurl = http://yum.mariadb.org/${MARIADB_MAJOR}/rhel9-amd64/
 gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 enabled=1
 gpgcheck=1
@@ -1118,10 +1122,12 @@ if [[ $Server_OS = "CentOS" ]] ; then
   if [[ "$Server_OS_Version" = "9" ]]; then
     # Check if architecture is aarch64
     if uname -m | grep -q 'aarch64' ; then
-      # Run the following commands if architecture is aarch64
-      /usr/bin/crb enable
-      curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash
-      dnf install libxcrypt-compat -y
+      if [[ "${Remote_MySQL^^}" != "ON" ]] ; then
+        # Run the following commands if architecture is aarch64 and local MySQL is desired
+        /usr/bin/crb enable
+        curl -sS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version=${MARIADB_VERSION}
+        dnf install libxcrypt-compat -y
+      fi
     fi
 
     # check if OS is AlmaLinux
@@ -1175,6 +1181,7 @@ if [[ $Server_OS = "CentOS" ]] ; then
     curl -o /etc/yum.repos.d/powerdns-auth-43.repo https://cyberpanel.sh/repo.powerdns.com/repo-files/centos-auth-43.repo
       Check_Return "yum repo" "no_exit"
 
+    if [[ "$Remote_MySQL" != "On" ]] ; then
     cat <<EOF >/etc/yum.repos.d/MariaDB.repo
 # MariaDB 10.4 CentOS repository list - created 2021-08-06 02:01 UTC
 # http://downloads.mariadb.org/mariadb/repositories/
@@ -1184,6 +1191,7 @@ baseurl = http://yum.mariadb.org/10.4/centos7-amd64
 gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1
 EOF
+    fi
 
     yum install --nogpg -y https://cyberpanel.sh/mirror.ghettoforge.org/distributions/gf/gf-release-latest.gf.el7.noarch.rpm
       Check_Return "yum repo" "no_exit"
@@ -1260,9 +1268,11 @@ fi
 Pre_Install_Setup_CN_Repository() {
 if [[ "$Server_OS" = "CentOS" ]] && [[ "$Server_OS_Version" = "7" ]]; then
 
-  sed -i 's|http://yum.mariadb.org|https://cyberpanel.sh/yum.mariadb.org|g' /etc/yum.repos.d/MariaDB.repo
-  sed -i 's|https://yum.mariadb.org/RPM-GPG-KEY-MariaDB|https://cyberpanel.sh/yum.mariadb.org/RPM-GPG-KEY-MariaDB|g' /etc/yum.repos.d/MariaDB.repo
-  # use MariaDB Mirror
+  if [[ "$Remote_MySQL" != "On" ]]; then
+    sed -i 's|http://yum.mariadb.org|https://cyberpanel.sh/yum.mariadb.org|g' /etc/yum.repos.d/MariaDB.repo
+    sed -i 's|https://yum.mariadb.org/RPM-GPG-KEY-MariaDB|https://cyberpanel.sh/yum.mariadb.org/RPM-GPG-KEY-MariaDB|g' /etc/yum.repos.d/MariaDB.repo
+    # use MariaDB Mirror
+  fi
 
   sed -i 's|https://download.copr.fedorainfracloud.org|https://cyberpanel.sh/download.copr.fedorainfracloud.org|g' /etc/yum.repos.d/_copr_copart-restic.repo
 
@@ -1313,22 +1323,34 @@ if [[ "$Server_OS" = "CentOS" ]] || [[ "$Server_OS" = "openEuler" ]] ; then
   # Could add a --skip-system-update flag to bypass this
   yum update -y
   if [[ "$Server_OS_Version" = "7" ]] ; then
-    yum install -y wget strace net-tools curl which bc telnet htop libevent-devel gcc libattr-devel xz-devel gpgme-devel curl-devel git socat openssl-devel MariaDB-shared mariadb-devel yum-utils python36u python36u-pip python36u-devel zip unzip bind-utils
+    PKGS="wget strace net-tools curl which bc telnet htop libevent-devel gcc libattr-devel xz-devel gpgme-devel curl-devel git socat openssl-devel yum-utils python36u python36u-pip python36u-devel zip unzip bind-utils"
+    if [[ "$Remote_MySQL" != "On" ]] ; then
+      PKGS+=" MariaDB-shared mariadb-devel"
+    fi
+    yum install -y $PKGS
       Check_Return
     yum -y groupinstall development
       Check_Return
   elif [[ "$Server_OS_Version" = "8" ]] ; then
-    dnf install -y libnsl zip wget strace net-tools curl which bc telnet htop libevent-devel gcc libattr-devel xz-devel mariadb-devel curl-devel git platform-python-devel tar socat python3 zip unzip bind-utils gpgme-devel
+    PKGS="libnsl zip wget strace net-tools curl which bc telnet htop libevent-devel gcc libattr-devel xz-devel curl-devel git platform-python-devel tar socat python3 zip unzip bind-utils gpgme-devel"
+    if [[ "$Remote_MySQL" != "On" ]] ; then
+      PKGS+=" mariadb-devel"
+    fi
+    dnf install -y $PKGS
       Check_Return
   elif [[ "$Server_OS_Version" = "9" ]] ; then
-
-    #!/bin/bash
-
-
-    dnf install -y libnsl zip wget strace net-tools curl which bc telnet htop libevent-devel gcc libattr-devel xz-devel MariaDB-server MariaDB-client MariaDB-devel curl-devel git platform-python-devel tar socat python3 zip unzip bind-utils gpgme-devel openssl-devel
+    PKGS="libnsl zip wget strace net-tools curl which bc telnet htop libevent-devel gcc libattr-devel xz-devel curl-devel git platform-python-devel tar socat python3 zip unzip bind-utils gpgme-devel openssl-devel"
+    if [[ "$Remote_MySQL" != "On" ]] ; then
+      PKGS+=" MariaDB-server-${MARIADB_VERSION} MariaDB-client-${MARIADB_VERSION} MariaDB-devel-${MARIADB_VERSION}"
+    fi
+    dnf install -y $PKGS
       Check_Return
   elif [[ "$Server_OS_Version" = "20" ]] || [[ "$Server_OS_Version" = "22" ]] ; then
-    dnf install -y libnsl zip wget strace net-tools curl which bc telnet htop libevent-devel gcc libattr-devel xz-devel mariadb-devel curl-devel git python3-devel tar socat python3 zip unzip bind-utils gpgme-devel
+    PKGS="libnsl zip wget strace net-tools curl which bc telnet htop libevent-devel gcc libattr-devel xz-devel curl-devel git python3-devel tar socat python3 zip unzip bind-utils gpgme-devel"
+    if [[ "$Remote_MySQL" != "On" ]] ; then
+      PKGS+=" mariadb-devel"
+    fi
+    dnf install -y $PKGS
       Check_Return
   fi
   ln -s /usr/bin/pip3 /usr/bin/pip
@@ -1343,10 +1365,18 @@ else
   fi
 
   if [[ "$Server_OS_Version" = "22" ]] ; then
-    DEBIAN_FRONTEND=noninteractive apt install -y dnsutils net-tools htop telnet libcurl4-gnutls-dev libgnutls28-dev libgcrypt20-dev libattr1 libattr1-dev liblzma-dev libgpgme-dev libcurl4-gnutls-dev libssl-dev nghttp2 libnghttp2-dev idn2 libidn2-dev libidn2-0-dev librtmp-dev libpsl-dev nettle-dev libgnutls28-dev libldap2-dev libgssapi-krb5-2 libk5crypto3 libkrb5-dev libcomerr2 libldap2-dev virtualenv git socat vim unzip zip libmariadb-dev-compat libmariadb-dev
+    PKGS="dnsutils net-tools htop telnet libcurl4-gnutls-dev libgnutls28-dev libgcrypt20-dev libattr1 libattr1-dev liblzma-dev libgpgme-dev libcurl4-gnutls-dev libssl-dev nghttp2 libnghttp2-dev idn2 libidn2-dev libidn2-0-dev librtmp-dev libpsl-dev nettle-dev libgnutls28-dev libldap2-dev libgssapi-krb5-2 libk5crypto3 libkrb5-dev libcomerr2 libldap2-dev virtualenv git socat vim unzip zip"
+    if [[ "$Remote_MySQL" != "On" ]] ; then
+      PKGS+=" libmariadb-dev-compat libmariadb-dev"
+    fi
+    DEBIAN_FRONTEND=noninteractive apt install -y $PKGS
      Check_Return
   else
-    DEBIAN_FRONTEND=noninteractive apt install -y dnsutils net-tools htop telnet libcurl4-gnutls-dev libgnutls28-dev libgcrypt20-dev libattr1 libattr1-dev liblzma-dev libgpgme-dev libmariadbclient-dev libcurl4-gnutls-dev libssl-dev nghttp2 libnghttp2-dev idn2 libidn2-dev libidn2-0-dev librtmp-dev libpsl-dev nettle-dev libgnutls28-dev libldap2-dev libgssapi-krb5-2 libk5crypto3 libkrb5-dev libcomerr2 libldap2-dev virtualenv git socat vim unzip zip
+    PKGS="dnsutils net-tools htop telnet libcurl4-gnutls-dev libgnutls28-dev libgcrypt20-dev libattr1 libattr1-dev liblzma-dev libgpgme-dev libcurl4-gnutls-dev libssl-dev nghttp2 libnghttp2-dev idn2 libidn2-dev libidn2-0-dev librtmp-dev libpsl-dev nettle-dev libgnutls28-dev libldap2-dev libgssapi-krb5-2 libk5crypto3 libkrb5-dev libcomerr2 libldap2-dev virtualenv git socat vim unzip zip"
+    if [[ "$Remote_MySQL" != "On" ]] ; then
+      PKGS+=" libmariadbclient-dev"
+    fi
+    DEBIAN_FRONTEND=noninteractive apt install -y $PKGS
      Check_Return
   fi
 

--- a/cyberpanel.sh
+++ b/cyberpanel.sh
@@ -1490,7 +1490,7 @@ if [[ "$Server_OS" = "CentOS" ]] ; then
     fi
     #CentOS 7 specific change
     if [[ "$Server_OS_Version" = "8" ]] ; then
-	      if grep -q -E "Rocky Linux" /etc/os-release ; then
+              if grep -q -E "Rocky Linux" /etc/os-release ; then
         if [[ "$Server_Country" = "CN" ]] ; then
           sed -i 's|rpm -Uvh http://rpms.litespeedtech.com/centos/litespeed-repo-1.1-1.el8.noarch.rpm|curl -o /etc/yum.repos.d/litespeed.repo https://cyberpanel.sh/litespeed/litespeed_cn.repo|g' install.py
         else
@@ -1498,7 +1498,16 @@ if [[ "$Server_OS" = "CentOS" ]] ; then
         fi
       fi
     fi
-    #CentOS 8 specific change
+    if [[ "$Server_OS_Version" = "9" ]] ; then
+              if grep -q -E "Rocky Linux" /etc/os-release ; then
+        if [[ "$Server_Country" = "CN" ]] ; then
+          sed -i 's|rpm -Uvh http://rpms.litespeedtech.com/centos/litespeed-repo-1.1-1.el9.noarch.rpm|curl -o /etc/yum.repos.d/litespeed.repo https://cyberpanel.sh/litespeed/litespeed_cn.repo|g' install.py
+        else
+          sed -i 's|rpm -Uvh http://rpms.litespeedtech.com/centos/litespeed-repo-1.1-1.el9.noarch.rpm|curl -o /etc/yum.repos.d/litespeed.repo https://cyberpanel.sh/litespeed/litespeed.repo|g' install.py
+        fi
+      fi
+    fi
+    #CentOS specific change
 
 elif  [[ "$Server_OS" = "Ubuntu" ]] ; then
     if [[ "$Server_OS_Version" = "20" ]] ; then

--- a/install/installCyberPanel.py
+++ b/install/installCyberPanel.py
@@ -10,6 +10,10 @@ from os.path import exists
 import time
 import install_utils
 
+# Pin MariaDB to latest LTS
+MARIADB_VERSION = "10.11.4"
+MARIADB_MAJOR = ".".join(MARIADB_VERSION.split('.')[:2])
+
 # distros - using from install_utils
 centos = install_utils.centos
 ubuntu = install_utils.ubuntu
@@ -336,6 +340,10 @@ class InstallCyberPanel:
             InstallCyberPanel.stdOut("LiteSpeed PHPs successfully installed!", 1)
 
     def installMySQL(self, mysql):
+        # Skip repository setup entirely if a remote database is configured
+        if str(self.remotemysql).upper() == 'ON':
+            install_utils.writeToFile('Remote MySQL detected, skipping MariaDB repository setup.')
+            return
 
         ############## Install mariadb ######################
 
@@ -351,20 +359,20 @@ class InstallCyberPanel:
             install_utils.call(command, self.distro, command, command, 1, 1, os.EX_OSERR)
             RepoPath = '/etc/apt/sources.list.d/mariadb.sources'
             RepoContent = f"""
-# MariaDB 10.11 repository list - created 2023-12-11 07:53 UTC
+# MariaDB {MARIADB_MAJOR} repository list - created 2023-12-11 07:53 UTC
 # https://mariadb.org/download/
 X-Repolib-Name: MariaDB
 Types: deb
 # deb.mariadb.org is a dynamic mirror if your preferred mirror goes offline. See https://mariadb.org/mirrorbits/ for details.
-# URIs: https://deb.mariadb.org/10.11/ubuntu
-URIs: https://mirrors.gigenet.com/mariadb/repo/10.11/ubuntu
+# URIs: https://deb.mariadb.org/{MARIADB_MAJOR}/ubuntu
+URIs: https://mirrors.gigenet.com/mariadb/repo/{MARIADB_MAJOR}/ubuntu
 Suites: jammy
 Components: main main/debug
 Signed-By: /etc/apt/keyrings/mariadb-keyring.pgp
 """
 
             if get_Ubuntu_release() > 21.00:
-                command = 'curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version=10.11'
+                command = f'curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version={MARIADB_VERSION}'
                 result = install_utils.call(command, self.distro, command, command, 1, 0, os.EX_OSERR, True)
                 
                 # If the download fails, use manual repo configuration as fallback
@@ -382,13 +390,13 @@ Signed-By: /etc/apt/keyrings/mariadb-keyring.pgp
                     # Use multiple mirror options for better reliability
                     RepoPath = '/etc/apt/sources.list.d/mariadb.list'
                     codename = get_Ubuntu_code_name()
-                    RepoContent = f"""# MariaDB 10.11 repository list - manual fallback
+                    RepoContent = f"""# MariaDB {MARIADB_MAJOR} repository list - manual fallback
 # Primary mirror
-deb [arch=amd64,arm64,ppc64el,s390x signed-by=/usr/share/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/10.11/ubuntu {codename} main
+deb [arch=amd64,arm64,ppc64el,s390x signed-by=/usr/share/keyrings/mariadb-keyring.pgp] https://mirror.mariadb.org/repo/{MARIADB_MAJOR}/ubuntu {codename} main
 
 # Alternative mirrors (uncomment if primary fails)
-# deb [arch=amd64,arm64,ppc64el,s390x signed-by=/usr/share/keyrings/mariadb-keyring.pgp] https://mirrors.gigenet.com/mariadb/repo/10.11/ubuntu {codename} main
-# deb [arch=amd64,arm64,ppc64el,s390x signed-by=/usr/share/keyrings/mariadb-keyring.pgp] https://ftp.osuosl.org/pub/mariadb/repo/10.11/ubuntu {codename} main
+# deb [arch=amd64,arm64,ppc64el,s390x signed-by=/usr/share/keyrings/mariadb-keyring.pgp] https://mirrors.gigenet.com/mariadb/repo/{MARIADB_MAJOR}/ubuntu {codename} main
+# deb [arch=amd64,arm64,ppc64el,s390x signed-by=/usr/share/keyrings/mariadb-keyring.pgp] https://ftp.osuosl.org/pub/mariadb/repo/{MARIADB_MAJOR}/ubuntu {codename} main
 """
                     
                     WriteToFile = open(RepoPath, 'w')
@@ -410,10 +418,10 @@ deb [arch=amd64,arm64,ppc64el,s390x signed-by=/usr/share/keyrings/mariadb-keyrin
             RepoContent = f"""
 [mariadb]
 name = MariaDB
-baseurl = http://yum.mariadb.org/10.11/rhel8-amd64
+baseurl = http://yum.mariadb.org/{MARIADB_MAJOR}/rhel8-amd64
 module_hotfixes=1
 gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck=1            
+gpgcheck=1
 """
             WriteToFile = open(RepoPath, 'w')
             WriteToFile.write(RepoContent)
@@ -442,7 +450,7 @@ gpgcheck=1
 
             else:
 
-                command = 'curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version=10.11'
+                command = f'curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash -s -- --mariadb-server-version={MARIADB_VERSION}'
                 install_utils.call(command, self.distro, command, command, 1, 1, os.EX_OSERR, True)
 
                 command = 'yum remove mariadb* -y'
@@ -455,7 +463,7 @@ gpgcheck=1
                 install_utils.call(command, self.distro, command, command, 1, 1, os.EX_OSERR, True)
 
 
-                command = 'dnf install MariaDB-server MariaDB-client MariaDB-backup -y'
+                command = f'dnf install MariaDB-server-{MARIADB_VERSION} MariaDB-client-{MARIADB_VERSION} MariaDB-backup-{MARIADB_VERSION} -y'
 
         install_utils.call(command, self.distro, command, command, 1, 1, os.EX_OSERR, True)
 

--- a/plogical/ftpUtilities.py
+++ b/plogical/ftpUtilities.py
@@ -145,7 +145,7 @@ class FTPUtilities:
 
             ProcessUtilities.decideDistro()
 
-            if ProcessUtilities.ubuntu22Check == 1 or ProcessUtilities.alma9check:
+            if ProcessUtilities.ubuntu22Check == 1 or ProcessUtilities.rhel9check:
                 from crypt import crypt, METHOD_SHA512
                 FTPPass = crypt(password, METHOD_SHA512)
             else:

--- a/plogical/processUtilities.py
+++ b/plogical/processUtilities.py
@@ -19,7 +19,8 @@ class ProcessUtilities(multi.Thread):
     ubuntu = 0
     ubuntu20 = 3
     ubuntu22Check = 0
-    alma9check = 0
+    # Flag indicating if the underlying system is based on RHEL 9 (AlmaLinux 9, Rocky Linux 9, etc.)
+    rhel9check = 0
     server_address = '/usr/local/lscpd/admin/comm.sock'
     token = "unset"
     portPath = '/usr/local/lscp/conf/bind.conf'
@@ -190,7 +191,7 @@ class ProcessUtilities(multi.Thread):
                     return ProcessUtilities.cent8
                 if any(x in content for x in ['CentOS Linux release 9', 'AlmaLinux release 9', 'Rocky Linux release 9',
                                             'CloudLinux release 9']):
-                    ProcessUtilities.alma9check = 1
+                    ProcessUtilities.rhel9check = 1
                     return ProcessUtilities.cent9
 
         # Default to Ubuntu if no other distribution is detected


### PR DESCRIPTION
## Summary
- avoid installing MariaDB packages when remote MySQL is configured
- pin MariaDB installation to 10.11.4 across installer scripts
- prevent MariaDB repository setup when a remote database is selected

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a838b606e4832ea98edeedbbf1043f